### PR TITLE
ssmでコンソールにログインを簡単にする

### DIFF
--- a/.zsh/functions/ssm.zsh
+++ b/.zsh/functions/ssm.zsh
@@ -1,0 +1,5 @@
+ip_address=`ecs-cli ps | grep $1 | grep /app | awk '{print $3}' | awk -F':' '{print $1}' | head -n 1`
+
+instance_id=$(aws ec2 describe-instances --filters "Name=private-ip-address,Values=$ip_address" --query 'Reservations[].Instances[0].InstanceId' | tr -d '["\n ]')
+
+aws ssm start-session --target $instance_id


### PR DESCRIPTION
`./ssm.zsh サービス名`
でEC2インスタンスにログイン

例
`./ssm.zsh agnt-stg02`

---
ecs-sliが必要なので予めインストールする
https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/developerguide/ECS_CLI_installation.html